### PR TITLE
feat: enhance createMcpServer method to accept environment variables

### DIFF
--- a/backend/src/mcpserver/mcpserver.controller.ts
+++ b/backend/src/mcpserver/mcpserver.controller.ts
@@ -17,9 +17,10 @@ export class McpServerController {
     @Post()
     createMcpServer(
         @Body('name') name: string,
-        @Body('image') image: string
+        @Body('image') image: string,
+        @Body('env') env: object
     ): Promise<any> {
-        return this.McpServerService.createMcpServer(name, image);
+        return this.McpServerService.createMcpServer(name, image, env);
     }
 
     @Delete(":name")

--- a/backend/src/mcpserver/mcpserver.service.ts
+++ b/backend/src/mcpserver/mcpserver.service.ts
@@ -243,10 +243,13 @@ export class McpServerService {
         }
     }
 
-    async createMcpServer(name: string, image: string) {
+    async createMcpServer(name: string, image: string, envs: object) {
         try {
             const url = `${this.K8S_API_HOST}/apis/${this.K8S_API_GROUP}/${this.K8S_API_VERSION}/namespaces/${this.K8S_NAMESPACE}/${this.K8S_RESOURCE}`;
-            
+            const envArray = Object.entries(envs).map(([key, value]) => ({
+                name: key,
+                value: value
+            }));
             const requestBody = {
                 apiVersion: `${this.K8S_API_GROUP}/${this.K8S_API_VERSION}`,
                 kind: "MCPServer",
@@ -260,6 +263,7 @@ export class McpServerService {
                         name: "network",
                         type: "builtin"
                     },
+                    env: envArray,
                     port: 8080,
                     resources: {
                         limits: {


### PR DESCRIPTION
- Updated createMcpServer method in McpServerService to include an 'env' parameter for environment variables.
- Modified request body construction to incorporate environment variables as an array of key-value pairs.
- Adjusted createMcpServer method in McpServerController to handle the new 'env' parameter.