### PR TITLE
fix(docker): 更新PostgreSQL镜像版本并修改端口映射

### DIFF
--- a/backend/docker/docker-compose.yaml
+++ b/backend/docker/docker-compose.yaml
@@ -2,14 +2,14 @@ version: '3.9'
 
 services:
   postgres:
-    image: postgres
+    image: postgres:15.12
     container_name: mcp-postgres
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: mcpforge
     ports:
-      - "5435:5432"
+      - "5433:5432"
     volumes:
       - ./data/postgres:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
将PostgreSQL镜像版本更新至15.12以修复潜在安全问题
修改端口映射从5435到5433以避免冲突